### PR TITLE
replace deprecated code

### DIFF
--- a/validation/validation_cp/test_csd_clamp.py
+++ b/validation/validation_cp/test_csd_clamp.py
@@ -307,7 +307,7 @@ class TestCSDClamp(unittest.TestCase):
 
 def suite():
     all_tests = []
-    all_tests.append(unittest.makeSuite(TestCSDClamp, "test"))
+    all_tests.append(unittest.TestLoader().loadTestsFromTestCase(TestCSDClamp))
     return unittest.TestSuite(all_tests)
 
 if __name__ == "__main__":

--- a/validation/validation_cp/test_masteq_diff.py
+++ b/validation/validation_cp/test_masteq_diff.py
@@ -154,7 +154,7 @@ class TestMasteqDiff(unittest.TestCase):
 
 def suite():
     all_tests = []
-    all_tests.append(unittest.makeSuite(TestMasteqDiff, "test"))
+    all_tests.append(unittest.TestLoader().loadTestsFromTestCase(TestMasteqDiff))
     return unittest.TestSuite(all_tests)
 
 if __name__ == "__main__":

--- a/validation/validation_cp/test_unbdiff.py
+++ b/validation/validation_cp/test_unbdiff.py
@@ -238,7 +238,7 @@ class TestUnboundedDiffusion(unittest.TestCase):
 
 def suite():
     all_tests = []
-    all_tests.append(unittest.makeSuite(TestUnboundedDiffusion, "test"))
+    all_tests.append(unittest.TestLoader().loadTestsFromTestCase(TestUnboundedDiffusion))
     return unittest.TestSuite(all_tests)
 
 if __name__ == "__main__":

--- a/validation/validation_efield/test_rallpack3.py
+++ b/validation/validation_efield/test_rallpack3.py
@@ -408,7 +408,7 @@ class TestRallpack3(unittest.TestCase):
 
 def suite():
     all_tests = []
-    all_tests.append(unittest.makeSuite(TestRallpack3, "test"))
+    all_tests.append(unittest.TestLoader().loadTestsFromTestCase(TestRallpack3))
     return unittest.TestSuite(all_tests)
 
 if __name__ == "__main__":

--- a/validation/validation_efield_mpi/parallel_rallpack1_dist.py
+++ b/validation/validation_efield_mpi/parallel_rallpack1_dist.py
@@ -55,7 +55,7 @@ class TestRallpack1(unittest.TestCase):
 
 def suite():
     all_tests = []
-    all_tests.append(unittest.makeSuite(TestRallpack1, "test"))
+    all_tests.append(unittest.TestLoader().loadTestsFromTestCase(TestRallpack1))
     return unittest.TestSuite(all_tests)
 
 if __name__ == "__main__":

--- a/validation/validation_rd/test_bounddiff.py
+++ b/validation/validation_rd/test_bounddiff.py
@@ -267,7 +267,7 @@ class TestBoundedDiffusion(unittest.TestCase):
 
 def suite():
     all_tests = []
-    all_tests.append(unittest.makeSuite(TestBoundedDiffusion, "test"))
+    all_tests.append(unittest.TestLoader().loadTestsFromTestCase(TestBoundedDiffusion))
     return unittest.TestSuite(all_tests)
 
 if __name__ == "__main__":

--- a/validation/validation_rd/test_constsourcediff_reac_ode.py
+++ b/validation/validation_rd/test_constsourcediff_reac_ode.py
@@ -282,7 +282,7 @@ class TestConstSourceDiffReacODE(unittest.TestCase):
 
 def suite():
     all_tests = []
-    all_tests.append(unittest.makeSuite(TestConstSourceDiffReacODE, "test"))
+    all_tests.append(unittest.TestLoader().loadTestsFromTestCase(TestConstSourceDiffReacODE))
     return unittest.TestSuite(all_tests)
 
 if __name__ == "__main__":

--- a/validation/validation_rd/test_csd_clamp.py
+++ b/validation/validation_rd/test_csd_clamp.py
@@ -266,7 +266,7 @@ class TestCSDClamp(unittest.TestCase):
 
 def suite():
     all_tests = []
-    all_tests.append(unittest.makeSuite(TestCSDClamp, "test"))
+    all_tests.append(unittest.TestLoader().loadTestsFromTestCase(TestCSDClamp))
     return unittest.TestSuite(all_tests)
 
 if __name__ == "__main__":

--- a/validation/validation_rd/test_kis_ode.py
+++ b/validation/validation_rd/test_kis_ode.py
@@ -267,7 +267,7 @@ class TestKISODE(unittest.TestCase):
 
 def suite():
     all_tests = []
-    all_tests.append(unittest.makeSuite(TestKISODE, "test"))
+    all_tests.append(unittest.TestLoader().loadTestsFromTestCase(TestKISODE))
     return unittest.TestSuite(all_tests)
 
 if __name__ == "__main__":

--- a/validation/validation_rd/test_masteq_diff.py
+++ b/validation/validation_rd/test_masteq_diff.py
@@ -131,7 +131,7 @@ class TestMasteqDiff(unittest.TestCase):
 
 def suite():
     all_tests = []
-    all_tests.append(unittest.makeSuite(TestMasteqDiff, "test"))
+    all_tests.append(unittest.TestLoader().loadTestsFromTestCase(TestMasteqDiff))
     return unittest.TestSuite(all_tests)
 
 if __name__ == "__main__":

--- a/validation/validation_rd/test_unbdiff.py
+++ b/validation/validation_rd/test_unbdiff.py
@@ -187,7 +187,7 @@ class TestUnbDiff(unittest.TestCase):
 
 def suite():
     all_tests = []
-    all_tests.append(unittest.makeSuite(TestUnbDiff, "test"))
+    all_tests.append(unittest.TestLoader().loadTestsFromTestCase(TestUnbDiff))
     return unittest.TestSuite(all_tests)
 
 if __name__ == "__main__":

--- a/validation/validation_rd/test_unbdiff2D_linesource_ring_ode.py
+++ b/validation/validation_rd/test_unbdiff2D_linesource_ring_ode.py
@@ -196,7 +196,7 @@ class TestUnbDiff2DLineSourceRingODE(unittest.TestCase):
 
 def suite():
     all_tests = []
-    all_tests.append(unittest.makeSuite(TestUnbDiff2DLineSourceRingODE, "test"))
+    all_tests.append(unittest.TestLoader().loadTestsFromTestCase(TestUnbDiff2DLineSourceRingODE))
     return unittest.TestSuite(all_tests)
 
 if __name__ == "__main__":

--- a/validation/validation_rd/test_unbdiff_ode.py
+++ b/validation/validation_rd/test_unbdiff_ode.py
@@ -250,7 +250,7 @@ class TestUnbDiffODE(unittest.TestCase):
 
 def suite():
     all_tests = []
-    all_tests.append(unittest.makeSuite(TestUnbDiffODE, "test"))
+    all_tests.append(unittest.TestLoader().loadTestsFromTestCase(TestUnbDiffODE))
     return unittest.TestSuite(all_tests)
 
 if __name__ == "__main__":

--- a/validation/validation_rd_dist/distributed_bounddiff.py
+++ b/validation/validation_rd_dist/distributed_bounddiff.py
@@ -146,7 +146,7 @@ class TestBoundDiff(unittest.TestCase):
 
 def suite():
     all_tests = []
-    all_tests.append(unittest.makeSuite(TestBoundDiff, "test"))
+    all_tests.append(unittest.TestLoader().loadTestsFromTestCase(TestBoundDiff))
     return unittest.TestSuite(all_tests)
 
 if __name__ == "__main__":

--- a/validation/validation_rd_dist/distributed_kisilevich.py
+++ b/validation/validation_rd_dist/distributed_kisilevich.py
@@ -216,7 +216,7 @@ class TestKisilevich(unittest.TestCase):
 
 def suite():
     all_tests = []
-    all_tests.append(unittest.makeSuite(TestKisilevich, "test"))
+    all_tests.append(unittest.TestLoader().loadTestsFromTestCase(TestKisilevich))
     return unittest.TestSuite(all_tests)
 
 if __name__ == "__main__":

--- a/validation/validation_rd_dist/distributed_masteq_diff.py
+++ b/validation/validation_rd_dist/distributed_masteq_diff.py
@@ -110,7 +110,7 @@ class TestMasteqDiff(unittest.TestCase):
 
 def suite():
     all_tests = []
-    all_tests.append(unittest.makeSuite(TestMasteqDiff, "test"))
+    all_tests.append(unittest.TestLoader().loadTestsFromTestCase(TestMasteqDiff))
     return unittest.TestSuite(all_tests)
 
 if __name__ == "__main__":

--- a/validation/validation_rd_dist/distributed_unbdiff.py
+++ b/validation/validation_rd_dist/distributed_unbdiff.py
@@ -119,7 +119,7 @@ class TestUnbDiff(unittest.TestCase):
 
 def suite():
     all_tests = []
-    all_tests.append(unittest.makeSuite(TestUnbDiff, "test"))
+    all_tests.append(unittest.TestLoader().loadTestsFromTestCase(TestUnbDiff))
     return unittest.TestSuite(all_tests)
 
 if __name__ == "__main__":

--- a/validation/validation_rd_mpi/parallel_bounddiff.py
+++ b/validation/validation_rd_mpi/parallel_bounddiff.py
@@ -249,7 +249,7 @@ class TestBoundDiff(unittest.TestCase):
 
 def suite():
     all_tests = []
-    all_tests.append(unittest.makeSuite(TestBoundDiff, "test"))
+    all_tests.append(unittest.TestLoader().loadTestsFromTestCase(TestBoundDiff))
     return unittest.TestSuite(all_tests)
 
 if __name__ == "__main__":

--- a/validation/validation_rd_mpi/parallel_csd_clamp.py
+++ b/validation/validation_rd_mpi/parallel_csd_clamp.py
@@ -248,7 +248,7 @@ class TestCSDClamp(unittest.TestCase):
 
 def suite():
     all_tests = []
-    all_tests.append(unittest.makeSuite(TestCSDClamp, "test"))
+    all_tests.append(unittest.TestLoader().loadTestsFromTestCase(TestCSDClamp))
     return unittest.TestSuite(all_tests)
 
 if __name__ == "__main__":

--- a/validation/validation_rd_mpi/parallel_kisilevich.py
+++ b/validation/validation_rd_mpi/parallel_kisilevich.py
@@ -251,7 +251,7 @@ class TestKisilevich(unittest.TestCase):
 
 def suite():
     all_tests = []
-    all_tests.append(unittest.makeSuite(TestKisilevich, "test"))
+    all_tests.append(unittest.TestLoader().loadTestsFromTestCase(TestKisilevich))
     return unittest.TestSuite(all_tests)
 
 if __name__ == "__main__":

--- a/validation/validation_rd_mpi/parallel_masteq_diff.py
+++ b/validation/validation_rd_mpi/parallel_masteq_diff.py
@@ -119,7 +119,7 @@ class TestMasteqDiff(unittest.TestCase):
 
 def suite():
     all_tests = []
-    all_tests.append(unittest.makeSuite(TestMasteqDiff, "test"))
+    all_tests.append(unittest.TestLoader().loadTestsFromTestCase(TestMasteqDiff))
     return unittest.TestSuite(all_tests)
 
 if __name__ == "__main__":

--- a/validation/validation_rd_mpi/parallel_unbdiff.py
+++ b/validation/validation_rd_mpi/parallel_unbdiff.py
@@ -172,7 +172,7 @@ class TestUnbDiff(unittest.TestCase):
 
 def suite():
     all_tests = []
-    all_tests.append(unittest.makeSuite(TestUnbDiff, "test"))
+    all_tests.append(unittest.TestLoader().loadTestsFromTestCase(TestUnbDiff))
     return unittest.TestSuite(all_tests)
 
 if __name__ == "__main__":

--- a/validation/validation_rd_mpi/parallel_unbdiff2D.py
+++ b/validation/validation_rd_mpi/parallel_unbdiff2D.py
@@ -189,7 +189,7 @@ class TestUnbDiff2D(unittest.TestCase):
 
 def suite():
     all_tests = []
-    all_tests.append(unittest.makeSuite(TestUnbDiff2D, "test"))
+    all_tests.append(unittest.TestLoader().loadTestsFromTestCase(TestUnbDiff2D))
     return unittest.TestSuite(all_tests)
 
 if __name__ == "__main__":

--- a/validation/validation_rd_mpi/parallel_unbdiff2D_linesource_ring.py
+++ b/validation/validation_rd_mpi/parallel_unbdiff2D_linesource_ring.py
@@ -195,7 +195,7 @@ class TestUnbDiff2DLineSourceRing(unittest.TestCase):
 
 def suite():
     all_tests = []
-    all_tests.append(unittest.makeSuite(TestUnbDiff2DLineSourceRing, "test"))
+    all_tests.append(unittest.TestLoader().loadTestsFromTestCase(TestUnbDiff2DLineSourceRing))
     return unittest.TestSuite(all_tests)
 
 if __name__ == "__main__":


### PR DESCRIPTION
I only replace `unittest.makeSuite` with `unittest.TestLoader().loadTestsFromTestCase`.