### PR TITLE
Add a step for loading the data only during stepsblender validation

### DIFF
--- a/stepsblender/run_blender_test.py
+++ b/stepsblender/run_blender_test.py
@@ -86,9 +86,16 @@ if __name__ == '__main__':
         dataPath = os.path.join(DATA_DIR, args.model)
         commonParams = [
             args.python, '-m', 'stepsblender.load', dataPath, '--blenderPath', args.blenderPath,
-            '--render', '--ignore_version'
+            '--ignore_version'
         ]
         commonParams += unknown_args
+
+        # No rendering, just data loading
+        printStage('Run data loading only')
+        ret = subprocess.run(commonParams + ['--blenderArgs', '-b --background'])
+        ret.check_returncode()
+
+        commonParams += ['--render']
 
         # Default render
         printStage('Run default rendering')


### PR DESCRIPTION
The other validation stages for `stepsblender` both use `--render` which forces the value of `--intersectAlgo` to `EXACT`. This PR adds a validation stage that doesn't use `--render` and so could detect issues with incorrect values of `--intersectAlgo`, in case Blender API changes.